### PR TITLE
Escape HTML tags

### DIFF
--- a/lib/web/assets/app.js
+++ b/lib/web/assets/app.js
@@ -174,24 +174,23 @@ window.App = (function (window, document) {
 
         return container;
     };
-    
-    
+
     /**
      * Escape HTML tags
      * @param  {String} text - String to escape
      * @return {String}        Escaped string
      * @private
      */
-    var _escape = function(text) {
+    var _escape = function (text) {
         var entityMap = {
-            "&": "&amp;",
-            "<": "&lt;",
-            ">": "&gt;",
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
             '"': '&quot;',
-            "'": '&#39;',
-            "/": '&#x2F;'
+            '\'': '&#39;',
+            '/': '&#x2F;'
         };
-        
+
         return String(text).replace(/[&<>"'\/]/g, function (s) {
             return entityMap[s];
         });
@@ -264,7 +263,7 @@ window.App = (function (window, document) {
             var div = document.createElement('div');
             var p = document.createElement('p');
             p.className = 'inner-line';
-            
+
             // Escape HTML tags
             data = _escape(data);
             p.innerHTML = _highlightWord(data);

--- a/lib/web/assets/app.js
+++ b/lib/web/assets/app.js
@@ -174,6 +174,28 @@ window.App = (function (window, document) {
 
         return container;
     };
+    
+    
+    /**
+     * Escape HTML tags
+     * @param  {String} text - String to escape
+     * @return {String}        Escaped string
+     * @private
+     */
+    var _escape = function(text) {
+        var entityMap = {
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': '&quot;',
+            "'": '&#39;',
+            "/": '&#x2F;'
+        };
+        
+        return String(text).replace(/[&<>"'\/]/g, function (s) {
+            return entityMap[s];
+        });
+    };
 
     return {
         /**
@@ -242,7 +264,9 @@ window.App = (function (window, document) {
             var div = document.createElement('div');
             var p = document.createElement('p');
             p.className = 'inner-line';
-
+            
+            // Escape HTML tags
+            data = _escape(data);
             p.innerHTML = _highlightWord(data);
 
             div.className = 'line';


### PR DESCRIPTION
Log lines containing pseudo-HTML-tags like this:

```
<Response [200]>
```

were treated as HTML and shown as invisible tags.