### PR TITLE
Fix for tail'ing over network

### DIFF
--- a/lib/tail.js
+++ b/lib/tail.js
@@ -25,9 +25,10 @@ var Tail = function (path, options) {
     }
 
     tail.stderr.on('data', function (data) {
-        //if there is any error then display it in the console and then kill the tail.
-        console.error(data.toString());
-        process.exit();
+        //if there is any important errors then display it in the console. Tail will keep running.
+        if (data.toString().indexOf('file truncated') === -1) { // File kan be truncated over network.
+            console.error(data.toString());
+        }
     });
 
     tail.stdout.on('data', function (data) {


### PR DESCRIPTION
Do not kill tail on error. Just log. File trunkcated is common on
tailing over windows. 