### PR TITLE
Fix line breaks for large lines

### DIFF
--- a/lib/tail.js
+++ b/lib/tail.js
@@ -40,7 +40,7 @@ function Tail(path, opts) {
       backlog += data.toString('utf-8');
       let n = backlog.indexOf('\n');
       while (n >= 0) {
-        let line = backlog.substring(0, n);
+        const line = backlog.substring(0, n);
         backlog = backlog.substring(n + 1);
         n = backlog.indexOf('\n');
         this._buffer.push(line);

--- a/lib/tail.js
+++ b/lib/tail.js
@@ -35,13 +35,17 @@ function Tail(path, opts) {
       }
     });
 
+    var backlog = "";
     tail.stdout.on('data', (data) => {
-      const lines = data.toString('utf-8').split('\n');
-      lines.pop();
-      lines.forEach((line) => {
+      backlog += data.toString('utf-8');
+      var n = backlog.indexOf('\n');
+      while (~n) {
+        var line = backlog.substring(0, n);
+        backlog = backlog.substring(n + 1);
+        n = backlog.indexOf('\n');
         this._buffer.push(line);
         this.emit('line', line);
-      });
+      }
     });
 
     process.on('exit', () => {

--- a/lib/tail.js
+++ b/lib/tail.js
@@ -35,11 +35,11 @@ function Tail(path, opts) {
       }
     });
 
-    var backlog = "";
+    let backlog = "";
     tail.stdout.on('data', (data) => {
       backlog += data.toString('utf-8');
-      var n = backlog.indexOf('\n');
-      while (~n) {
+      let n = backlog.indexOf('\n');
+      while (n >= 0) {
         var line = backlog.substring(0, n);
         backlog = backlog.substring(n + 1);
         n = backlog.indexOf('\n');

--- a/lib/tail.js
+++ b/lib/tail.js
@@ -35,12 +35,12 @@ function Tail(path, opts) {
       }
     });
 
-    let backlog = "";
+    let backlog = '';
     tail.stdout.on('data', (data) => {
       backlog += data.toString('utf-8');
       let n = backlog.indexOf('\n');
       while (n >= 0) {
-        var line = backlog.substring(0, n);
+        let line = backlog.substring(0, n);
         backlog = backlog.substring(n + 1);
         n = backlog.indexOf('\n');
         this._buffer.push(line);


### PR DESCRIPTION
There was a problem when reading large lines (up to 18030 chars). 
Some lines were fine, but in many cases a prefix of a line was missing. 

The fix is based on this snipplet:
https://gist.github.com/TooTallNate/1785026