### PR TITLE
Add viewport width to support responsive design

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
 <head>
     <title>tail -F __TITLE__</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="__PATH__/styles/__THEME__.css">
     <link rel="icon" href="__PATH__/favicon.ico">
 </head>


### PR DESCRIPTION
The UI is built to respond to the width of the screen it is being
displayed on and provide the best experience across device. When I tried
to view logs streaming on my phone (Apple iPhone 6s), site was
attempting to render the "bigger-screen" version.

This is because, by default, mobile browsers advertise a bigger "view
port" than screen size, to allow compatibility with non-responsive sites.
In order to benefit from the responsiveness provided the viewport meta
tag needs to be overwritten. More on that tag can be found at
[mdn](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag).

**Before**
<img width="486" alt="screen shot 2018-04-11 at 10 41 08" src="https://user-images.githubusercontent.com/2773538/38609053-080c2458-3d75-11e8-9dd7-1f1260a44688.png">

**After**
<img width="484" alt="screen shot 2018-04-11 at 10 41 24" src="https://user-images.githubusercontent.com/2773538/38609077-10e3e426-3d75-11e8-944e-b73364df2a0f.png">