### PR TITLE
add npmlog style preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ which means that every "err" string will be in red and every line containing "er
 
 _New presets are very welcome. If you don't like default or you would like to share yours, please create PR with json file._
 
+Available presets:
+- default
+- npmlog
+
 ### Running behind nginx
 
 Using the `--url-path` option `frontail` can run behind nginx with the example configuration

--- a/preset/npmlog.json
+++ b/preset/npmlog.json
@@ -1,0 +1,15 @@
+{
+  "words": {
+    "verb": "color: blue; background-color: black;",
+    "info": "color: green;",
+    "http": "color: green; background-color: black;",
+    "WARN": "color: black; background-color: yellow; font-style: normal;",
+    "error": "color: red;",
+    "ERR!": "color: red; background-color: black;"
+  },
+  "lines": {
+    "WARN": "font-style: italic;",
+    "ERR!": "font-weight: bold;"
+  }
+}
+


### PR DESCRIPTION
<img width="816" alt="screen shot 2018-08-14 at 03 55 50" src="https://user-images.githubusercontent.com/3145080/44067965-300ac2c4-9f78-11e8-8804-87fba26d2efd.png">
<img width="814" alt="screen shot 2018-08-14 at 03 54 35" src="https://user-images.githubusercontent.com/3145080/44067966-302a1282-9f78-11e8-89bd-927296f1a553.png">

follows npmlog style rules: https://github.com/npm/npmlog/blob/master/log.js (end of file)

`node index.js  <path>  --ui-highlight --ui-highlight-preset ./preset/npmlog.json`