### PR TITLE
keep empty lines

### DIFF
--- a/lib/tail.js
+++ b/lib/tail.js
@@ -17,7 +17,7 @@ function Tail(path, opts) {
   this._buffer = new CBuffer(options.buffer);
 
   if (path[0] === '-') {
-    byline(process.stdin).on('data', (line) => {
+    byline(process.stdin,{ keepEmptyLines: true }).on('data', (line) => {
       const str = line.toString();
       this._buffer.push(str);
       this.emit('line', str);
@@ -38,7 +38,7 @@ function Tail(path, opts) {
       }
     });
 
-    byline(tail.stdout).on('data', (line) => {
+    byline(tail.stdout,{ keepEmptyLines: true }).on('data', (line) => {
       const str = line.toString();
       this._buffer.push(str);
       this.emit('line', str);


### PR DESCRIPTION
this change permits frontail to capture empty lines instead of simply ignoring them. 
#172 