### PR TITLE
chore(docs): fix help option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
 
     Options:
 
-      -h, --help                    output usage information
       -V, --version                 output the version number
       -h, --host <host>             listening host, default 0.0.0.0
       -p, --port <port>             listening port, default 9001
@@ -59,6 +58,7 @@
       --ui-highlight-preset <path>  custom preset for highlighting (see ./preset/default.json)
       --path <path>                 prefix path for the running application, default /
       --disable-usage-stats         disable gathering usage statistics
+      --help                        output usage information
 
 Web interface runs on **http://127.0.0.1:[port]**.
 

--- a/lib/options_parser.js
+++ b/lib/options_parser.js
@@ -3,6 +3,7 @@ const program = require('commander');
 program
   .version(require('../package.json').version)
   .usage('[options] [file ...]')
+  .helpOption('--help')
   .option('-h, --host <host>', 'listening host, default 0.0.0.0', String, '0.0.0.0')
   .option('-p, --port <port>', 'listening port, default 9001', Number, 9001)
   .option('-n, --number <number>', 'starting lines number, default 10', Number, 10)

--- a/package-lock.json
+++ b/package-lock.json
@@ -646,19 +646,9 @@
       }
     },
     "commander": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
-      "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
-      "requires": {
-        "keypress": "0.1.x"
-      },
-      "dependencies": {
-        "keypress": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-          "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
-        }
-      }
+      "version": "3.0.0-0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.0-0.tgz",
+      "integrity": "sha512-b/YlgJi4Nn53KWvxsOU9Mz1Lr+ZK4tMUyDOk2IvB+Hki5eefYZusNOvLls91HeI2oWLyxJ3KMEU9QeEaRtTPFQ=="
     },
     "component-bind": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "CBuffer": "~0.1.4",
     "basic-auth-connect": "~1.0.0",
     "byline": "~5.0.0",
-    "commander": "~1.3.2",
+    "commander": "^3.0.0-0",
     "configstore": "~4.0.0",
     "connect": "~3.6.6",
     "cookie": "~0.1.0",


### PR DESCRIPTION
This should fix #53 after [commander.js@3.0.0](https://github.com/tj/commander.js/issues/1001) is released.

see [3.0.0/CHANGELOG](https://github.com/tj/commander.js/blob/release/3.0.0/CHANGELOG.md#300-0-prerelease--2019-07-28)