### PR TITLE
Add --title option to set HTML/header title

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ if (program.daemonize) {
       path.join(__dirname, 'web', 'index.html'),
       files,
       filesNamespace,
-      program.theme
+      program.theme,
+      program.title
     );
 
   const builder = serverBuilder();

--- a/lib/connect_builder.js
+++ b/lib/connect_builder.js
@@ -31,9 +31,11 @@ ConnectBuilder.prototype.index = function index(
   path,
   files,
   filesNamespace,
-  themeOpt
+  themeOpt,
+  titleOpt
 ) {
   const theme = themeOpt || 'default';
+  const title = titleOpt || `tail -f ${files}`;
 
   this.app.use(this.urlPath, (req, res) => {
     fs.readFile(path, (err, data) => {
@@ -43,7 +45,7 @@ ConnectBuilder.prototype.index = function index(
       res.end(
         data
           .toString('utf-8')
-          .replace(/__TITLE__/g, files)
+          .replace(/__TITLE__/g, title)
           .replace(/__THEME__/g, theme)
           .replace(/__NAMESPACE__/g, filesNamespace)
           .replace(/__PATH__/g, this.urlPath),

--- a/lib/daemonize.js
+++ b/lib/daemonize.js
@@ -23,7 +23,7 @@ module.exports = (script, params, opts) => {
     '-l',
     params.lines,
     '-t',
-    params.theme,
+    params.theme
   ];
 
   if (options.doAuthorization) {
@@ -40,6 +40,10 @@ module.exports = (script, params, opts) => {
 
   if (params.urlPath) {
     args.push('--url-path', params.urlPath);
+  }
+
+  if (params.title) {
+    args.push('--title', params.title);
   }
 
   if (!params.uiIndent) {

--- a/lib/options_parser.js
+++ b/lib/options_parser.js
@@ -72,6 +72,12 @@ program
     String,
     '/'
   )
+  .option(
+    '--title <title>',
+    'Title of page, default "tail -f <files>"',
+    String,
+    false
+  )
   .option('--ui-hide-topbar', 'hide topbar (log file name and search box)')
   .option('--ui-no-indent', "don't indent log lines")
   .option(

--- a/test/connect_builder.js
+++ b/test/connect_builder.js
@@ -69,12 +69,20 @@ describe('connectBuilder', () => {
       .expect('Content-Type', 'text/html', done);
   });
 
-  it('should build app that replace index title', (done) => {
+  it('should build app that populates index title with files', (done) => {
     const app = connectBuilder('/')
       .index(path.join(__dirname, 'fixtures/index_with_title'), '/testfile')
       .build();
 
-    request(app).get('/').expect('<head><title>/testfile</title></head>', done);
+    request(app).get('/').expect('<head><title>tail -f /testfile</title></head>', done);
+  });
+
+  it('should build app that populates index title with title argument', (done) => {
+    const app = connectBuilder('/')
+      .index(path.join(__dirname, 'fixtures/index_with_title'), '/testfile', false, false, 'TEST TITLE')
+      .build();
+
+    request(app).get('/').expect('<head><title>TEST TITLE</title></head>', done);
   });
 
   it('should build app that sets socket.io namespace based on files', (done) => {
@@ -103,7 +111,7 @@ describe('connectBuilder', () => {
     request(app)
       .get('/')
       .expect(
-        '<head><title>/testfile</title><link href="dark.css" rel="stylesheet" type="text/css"/></head>',
+        '<head><title>tail -f /testfile</title><link href="dark.css" rel="stylesheet" type="text/css"/></head>',
         done
       );
   });
@@ -116,7 +124,7 @@ describe('connectBuilder', () => {
     request(app)
       .get('/')
       .expect(
-        '<head><title>/testfile</title><link href="default.css" rel="stylesheet" type="text/css"/></head>',
+        '<head><title>tail -f /testfile</title><link href="default.css" rel="stylesheet" type="text/css"/></head>',
         done
       );
   });

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>tail -f __TITLE__</title>
+    <title>__TITLE__</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="__PATH__/styles/__THEME__.css">
@@ -14,7 +14,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col-sm-8">
-                    <span class="navbar-brand text-overflow" title="__TITLE__">tail -f __TITLE__</span>
+                    <span class="navbar-brand text-overflow" title="__TITLE__">__TITLE__</span>
                 </div>
                 <div class="col-sm-1 text-right">
                     <button type="button" class="btn btn-light btn-pause" data-toggle="button" aria-pressed="false" autocomplete="off"></button>


### PR DESCRIPTION
This PR adds an optional `--title` option for setting the HTML and header bar title instead of the default of `tail -f <files>`.